### PR TITLE
introduce `black` formatting

### DIFF
--- a/FX.py
+++ b/FX.py
@@ -8,6 +8,7 @@ import math
 from math import atan2, degrees, floor, sin, cos, radians, pi, sqrt
 import random
 
+
 class crash(pygame.sprite.Sprite):
     def __init__(self, coords):
         super().__init__()
@@ -24,7 +25,7 @@ class crash(pygame.sprite.Sprite):
         self.scale = 0
         self.fade = 0
         for i in range(0, 8):
-            spacing = (pi / 4)
+            spacing = pi / 4
             angle = (spacing * i) + (random.randint(-5, 5) / 50)
             radius = random.randint(20, 25)
             x = cos(angle) * 50 + 50
@@ -33,10 +34,14 @@ class crash(pygame.sprite.Sprite):
 
     def update(self):
         self.surf.fill((0, 0, 0))
-        self.innersurfx = pygame.transform.smoothscale(self.innersurf, ((100 + self.scale), (100 + self.scale)))
+        self.innersurfx = pygame.transform.smoothscale(
+            self.innersurf, ((100 + self.scale), (100 + self.scale))
+        )
         self.surf.set_alpha(255 - self.fade)
 
-        self.surf.blit(self.innersurfx, ((100 - (self.scale / 2)), (100 - (self.scale / 2))))
+        self.surf.blit(
+            self.innersurfx, ((100 - (self.scale / 2)), (100 - (self.scale / 2)))
+        )
         screen.blit(self.surf, self.rect)
         self.timer += 2
         self.scale += 20 - self.timer
@@ -44,8 +49,21 @@ class crash(pygame.sprite.Sprite):
         if self.timer > 10:
             self.kill()
 
-class blasticle():
-    def __init__(self, pos, vel, acc, size, dsize, ddsize, color, surface, colorchange, dcolorchange):
+
+class blasticle:
+    def __init__(
+        self,
+        pos,
+        vel,
+        acc,
+        size,
+        dsize,
+        ddsize,
+        color,
+        surface,
+        colorchange,
+        dcolorchange,
+    ):
         self.pos = vec(pos)
         self.vel = vec(vel)
         self.acc = vec(acc)
@@ -63,13 +81,13 @@ class blasticle():
     def draw(self):
         pygame.draw.circle(self.surface, self.color, self.pos, self.size, 0)
 
-        self.red += (self.colorchange[0] * self.dcolorchange)
+        self.red += self.colorchange[0] * self.dcolorchange
         if self.red < 10:
             self.red = 10
-        self.green += (self.colorchange[1] * self.dcolorchange)
+        self.green += self.colorchange[1] * self.dcolorchange
         if self.green < 10:
             self.green = 10
-        self.blue += (self.colorchange[2] * self.dcolorchange)
+        self.blue += self.colorchange[2] * self.dcolorchange
         if self.blue < 10:
             self.blue = 10
         self.color = (self.red, self.green, self.blue)
@@ -81,9 +99,21 @@ class blasticle():
         self.dsize += self.ddsize
 
 
-
-class particle():
-    def __init__(self, xpos, ypos, xvel, yvel, xacc, yacc, size, dsize, color, surface, colorchange):
+class particle:
+    def __init__(
+        self,
+        xpos,
+        ypos,
+        xvel,
+        yvel,
+        xacc,
+        yacc,
+        size,
+        dsize,
+        color,
+        surface,
+        colorchange,
+    ):
         self.xpos = xpos
         self.ypos = ypos
         self.xvel = xvel
@@ -99,6 +129,7 @@ class particle():
         self.red = self.color[0]
         self.blue = self.color[2]
         self.green = self.color[1]
+
     def draw(self):
         pygame.draw.circle(self.surface, self.color, self.center, self.size, 0)
 
@@ -109,12 +140,13 @@ class particle():
         self.xvel += self.xacc
         self.yvel += self.yacc
         if self.yvel > 0:
-            self.yvel = random.randrange(-1,1)
+            self.yvel = random.randrange(-1, 1)
         # self.xpos += self.xvel
         # self.ypos += self.ypos
         self.size += self.dsize
         self.center.x += self.xvel
         self.center.y += self.yvel
+
 
 class explosionhitbox(pygame.sprite.Sprite):
     def __init__(self, position):
@@ -126,6 +158,7 @@ class explosionhitbox(pygame.sprite.Sprite):
         self.rect.center = position
         self.expire = False
         self.damage = 3
+
     def update(self):
         enemieshit = pygame.sprite.spritecollide(self, enemies, False)
         if enemieshit:
@@ -160,7 +193,12 @@ class explosive(pygame.sprite.Sprite):
         self.fade = 10
         self.faderate = 1.5
 
-    def circly(self, size, expand, color,):
+    def circly(
+        self,
+        size,
+        expand,
+        color,
+    ):
         # self.blastsurf.fill((0, 0, 0))
         pygame.draw.circle(self.blastsurf, color, (100, 100), size)
         self.circleseedzise += expand
@@ -183,7 +221,18 @@ class explosive(pygame.sprite.Sprite):
             vel = vec(x, y)
             vel *= 10
             acc = vel * -0.1
-            part = blasticle((100, 100), vel, acc, size, 2.2, -0.8, (255, 255, 255), self.surf, (-5, -20, -30), 1.5)
+            part = blasticle(
+                (100, 100),
+                vel,
+                acc,
+                size,
+                2.2,
+                -0.8,
+                (255, 255, 255),
+                self.surf,
+                (-5, -20, -30),
+                1.5,
+            )
             self.list.append(part)
 
     def update(self):
@@ -213,8 +262,8 @@ class explosive(pygame.sprite.Sprite):
 class muzzleflash(pygame.sprite.Sprite):
     def __init__(self, color):
         super().__init__()
-        self.orig = pygame.surface.Surface((100,50))
-        self.orig.set_colorkey((0,0,0))
+        self.orig = pygame.surface.Surface((100, 50))
+        self.orig.set_colorkey((0, 0, 0))
         self.orig.set_alpha(200)
         self.rect = self.orig.get_rect()
         self.list = []
@@ -225,9 +274,8 @@ class muzzleflash(pygame.sprite.Sprite):
         self.color = color
 
     def update(self):
-
         self.timer += 1
-        self.orig.fill((0,0,0))
+        self.orig.fill((0, 0, 0))
         if self.color == 0:
             colorchange = (-15, -25, -60)
             color = (255, 255, 240)
@@ -243,7 +291,19 @@ class muzzleflash(pygame.sprite.Sprite):
                 random2 = random.randrange(0, 50)
                 random3 = random.randrange(-5, 5)
                 random4 = random.randrange(5, 15)
-                part = particle(random2, random1, random4, random3 ,0 ,(random3 * -0.2) , 5, -1, color, self.orig, colorchange)
+                part = particle(
+                    random2,
+                    random1,
+                    random4,
+                    random3,
+                    0,
+                    (random3 * -0.2),
+                    5,
+                    -1,
+                    color,
+                    self.orig,
+                    colorchange,
+                )
                 self.list.append(part)
         for i in self.list:
             i.draw()
@@ -278,13 +338,14 @@ class muzzleflash(pygame.sprite.Sprite):
         if gatling.firing == False:
             self.kill()
 
+
 class spriticle(pygame.sprite.Sprite):
     def __init__(self, coords, rotation):
         super().__init__()
-        self.orig = pygame.surface.Surface((100,100))
-        self.orig.set_colorkey((0,0,0))
-        self.splintscreen = pygame.surface.Surface((100,100))
-        self.splintscreen.set_colorkey((0,0,0))
+        self.orig = pygame.surface.Surface((100, 100))
+        self.orig.set_colorkey((0, 0, 0))
+        self.splintscreen = pygame.surface.Surface((100, 100))
+        self.splintscreen.set_colorkey((0, 0, 0))
         self.orig.set_alpha(255)
         self.alpha = 255
         self.fade = 0.85
@@ -304,15 +365,27 @@ class spriticle(pygame.sprite.Sprite):
         self.particlelist = []
         self.splinterlist = []
 
-        for i in range(random.randint(1,3)):
-            randomdir = random.randrange(-10,10)
+        for i in range(random.randint(1, 3)):
+            randomdir = random.randrange(-10, 10)
             xpos = 50
             ypos = 100
-            splinter = particle(xpos, ypos, randomdir , (-10 + randomdir), 0, 0, 5, -1, (255,220,150), self.splintscreen, (0,0,0))
+            splinter = particle(
+                xpos,
+                ypos,
+                randomdir,
+                (-10 + randomdir),
+                0,
+                0,
+                5,
+                -1,
+                (255, 220, 150),
+                self.splintscreen,
+                (0, 0, 0),
+            )
             self.splinterlist.append(splinter)
 
         for i in range(6):
-            randomized1 = random.randrange(-10,10) / 10
+            randomized1 = random.randrange(-10, 10) / 10
             randomized2 = random.randrange(-10, 10) / 10
             randomized3 = random.randrange(-10, 10) / 10
             randomized4 = random.randrange(-10, 10) / 10
@@ -320,12 +393,24 @@ class spriticle(pygame.sprite.Sprite):
 
             xpos = 50
             ypos = 100
-            part = particle(xpos,ypos, randomized1, (randomized2 * 2 - 22), (randomized3 / 20), (5 + (randomized4 / 20)), 1, (1 + (randomized5 / 2)), (50,40,10), self.orig, (0,0,0))
+            part = particle(
+                xpos,
+                ypos,
+                randomized1,
+                (randomized2 * 2 - 22),
+                (randomized3 / 20),
+                (5 + (randomized4 / 20)),
+                1,
+                (1 + (randomized5 / 2)),
+                (50, 40, 10),
+                self.orig,
+                (0, 0, 0),
+            )
             self.particlelist.append(part)
 
     def update(self):
         # self.orig.fill((0,0,0))
-        self.splintscreen.fill((0,0,0))
+        self.splintscreen.fill((0, 0, 0))
         for i in range(len(self.particlelist)):
             self.particlelist[i].draw()
         for i in range(len(self.splinterlist)):
@@ -341,6 +426,7 @@ class spriticle(pygame.sprite.Sprite):
         if self.timer > 15:
             self.kill()
 
+
 class organichit(pygame.sprite.Sprite):
     def __init__(self, coords):
         super().__init__()
@@ -355,8 +441,11 @@ class organichit(pygame.sprite.Sprite):
             xvel = random.randrange(-100, 100) / 10
             yvel = 10 - abs(xvel)
             yvel *= random.randint(-1, 1)
-            part = particle(50, 50, xvel, yvel, -1, -1, 3, -0.2, (240, 0, 0), self.surf, (0, 0, 0))
+            part = particle(
+                50, 50, xvel, yvel, -1, -1, 3, -0.2, (240, 0, 0), self.surf, (0, 0, 0)
+            )
             self.list.append(part)
+
     def update(self):
         self.surf.fill((0, 0, 0))
         for i in self.list:
@@ -365,7 +454,6 @@ class organichit(pygame.sprite.Sprite):
         screen.blit(self.surf, self.rect)
         if self.timer > 20:
             self.kill()
-
 
 
 class bullitimpact(pygame.sprite.Sprite):
@@ -384,9 +472,9 @@ class bullitimpact(pygame.sprite.Sprite):
         elif rotation == 270:
             self.rect.midleft = coords
 
-
         self.timer = 0
         self.rotation = rotation
+
     def update(self):
         self.timer += 1
         picnum = self.timer // 2

--- a/Lizzy.py
+++ b/Lizzy.py
@@ -12,6 +12,7 @@ from FX import *
 
 # simple placeholder sprite used to gauge level shift to use for saving and reverting during respawn
 
+
 class yardstick(pygame.sprite.Sprite):
     def __init__(self):
         super().__init__()
@@ -32,7 +33,8 @@ allsprites.add(schrevel)
 
 # arbiter class for game logic and storing global variables and stuff
 
-class arbiter():
+
+class arbiter:
     def __init__(self):
         self.angle = 0
         self.death = False
@@ -52,7 +54,6 @@ class arbiter():
         self.peiling = vec(0, 0)
 
     def update(self):
-
         self.angleget()
         self.save()
         self.scroll()
@@ -62,7 +63,6 @@ class arbiter():
     # a function for saving and reverting position upon death
 
     def save(self):
-
         if liz.grounded and not self.death:
             self.savetimer += 1
             if self.savetimer == 5:
@@ -109,15 +109,20 @@ class arbiter():
     def hud(self):
         lizhealth = pygame.Rect(20, 120, liz.health * 5, 5)
         pygame.draw.rect(screen, ("red"), lizhealth)
-        normalammocount = font.render("regular ammo: " + str(liz.ammo[0]), True, ("black"))
-        hvammocount = font.render("hyper velocity ammo: " + str(liz.ammo[1]), True, ("black"))
-        explosiveammocount = font.render("explosive ammo: " + str(liz.ammo[2]), True, ("black"))
+        normalammocount = font.render(
+            "regular ammo: " + str(liz.ammo[0]), True, ("black")
+        )
+        hvammocount = font.render(
+            "hyper velocity ammo: " + str(liz.ammo[1]), True, ("black")
+        )
+        explosiveammocount = font.render(
+            "explosive ammo: " + str(liz.ammo[2]), True, ("black")
+        )
         screen.blit(normalammocount, (40, 140))
         screen.blit(hvammocount, (40, 160))
         screen.blit(explosiveammocount, (40, 180))
         self.ammoselect = 155 + (liz.ammotype * 20)
         pygame.draw.circle(screen, (255, 255, 255), (20, self.ammoselect), 5)
-
 
     def virtpos(self):
         if self.xscrolling:
@@ -147,7 +152,9 @@ class arbiter():
     # scrolling the level.
 
     def scroll(self):
-        if (liz.pos.x >= self.sbright and liz.vel.x > 0) or (liz.pos.x <= self.sbleft and liz.vel.x < 0):
+        if (liz.pos.x >= self.sbright and liz.vel.x > 0) or (
+            liz.pos.x <= self.sbleft and liz.vel.x < 0
+        ):
             self.xscrolling = True
             for entity in allsprites:
                 position = list(entity.rect.center)
@@ -159,8 +166,13 @@ class arbiter():
 
         else:
             self.xscrolling = False
-        if (liz.pos.y >= self.sbbottom and liz.vel.y > 0 and self.virtualposition.y <= 800) or (
-                liz.pos.y <= self.sbtop and liz.vel.y < 0 and self.virtualposition.y >= -400):
+        if (
+            liz.pos.y >= self.sbbottom
+            and liz.vel.y > 0
+            and self.virtualposition.y <= 800
+        ) or (
+            liz.pos.y <= self.sbtop and liz.vel.y < 0 and self.virtualposition.y >= -400
+        ):
             self.yscrolling = True
             for entity in allsprites:
                 position = list(entity.rect.center)
@@ -194,7 +206,6 @@ class meleehurtbox(pygame.sprite.Sprite):
 
         whackedbeast = pygame.sprite.spritecollide(self, enemies, False)
         if whackedbeast:
-
             for i in whackedbeast:
                 i.gethit(self.rect.center, 10, "melee")
                 if self.orient == "left":
@@ -255,11 +266,9 @@ class Tracereffect(pygame.sprite.Sprite):
         self.internal = False
 
     def update(self):
-
         ping = hitdetector()
         ping.rect.center = self.pos
         for i in range(10):
-
             knal = pygame.sprite.spritecollide(ping, hardblocks, False)
             pats = pygame.sprite.spritecollide(ping, enemies, False)
             if (knal or pats) and not self.internal:
@@ -316,7 +325,6 @@ class Tracereffect(pygame.sprite.Sprite):
                         boem = FX.explosive(hits[0].rect.midleft)
                         allsprites.add(boem)
 
-
                 if exitss:
                     self.rotation += 180
                     if self.rotation > 360:
@@ -325,13 +333,14 @@ class Tracereffect(pygame.sprite.Sprite):
                     # allsprites.add(pow)
                     hits[i].gethit(exitss[0].rect.center, self.rotation)
                 if liz.ammotype != 2:
-
-                    screen.blit(hits[i].surf, hits[i].rect, )
+                    screen.blit(
+                        hits[i].surf,
+                        hits[i].rect,
+                    )
                 if liz.ammotype != 1:
                     self.kill()
 
         if pats and not knal:
-
             for i in splut:
                 if impactss:
                     if liz.ammotype != 2:
@@ -344,7 +353,6 @@ class Tracereffect(pygame.sprite.Sprite):
                 if liz.ammotype != 1:
                     self.kill()
                 if exitss:
-
                     i.gethit(exitss[0].rect.center, 0, "bullet")
 
         if self.tick > 20:
@@ -352,6 +360,7 @@ class Tracereffect(pygame.sprite.Sprite):
         if splut and not pats:
             for i in splut:
                 i.gethit(i.rect.center, 1, "bullet")
+
 
 class Reticle(pygame.sprite.Sprite):
     def __init__(self):
@@ -368,6 +377,7 @@ class Reticle(pygame.sprite.Sprite):
 
 
 # The animated spinning barrels for Lizzy's gatling.
+
 
 class barrels(pygame.sprite.Sprite):
     def __init__(self):
@@ -454,6 +464,7 @@ class barrels(pygame.sprite.Sprite):
 
 # Lizzy's legs, with walking and jumping animation
 
+
 class Lizlegs(pygame.sprite.Sprite):
     def __init__(self):
         super().__init__()
@@ -506,6 +517,7 @@ class Lizlegs(pygame.sprite.Sprite):
 
 # Lizzy's torso with gatling, which rotates based on angle between Lizzy and reticle
 
+
 class Liztorso(pygame.sprite.Sprite):
     def __init__(self):
         super().__init__()
@@ -533,7 +545,9 @@ class Liztorso(pygame.sprite.Sprite):
         if not self.reversed:
             self.surf = pygame.transform.rotate((self.aim[self.frame]), rotateangle)
         if self.reversed:
-            self.surf = pygame.transform.rotate((self.aim[self.frame]), (rotateangle * -1))
+            self.surf = pygame.transform.rotate(
+                (self.aim[self.frame]), (rotateangle * -1)
+            )
         self.rect = self.surf.get_rect()
 
     def reverse(self, speed, key):
@@ -544,6 +558,7 @@ class Liztorso(pygame.sprite.Sprite):
 
 
 # Lizzy's main control sprite with transparant surface and the rect hitbox.
+
 
 class LizMain(pygame.sprite.Sprite):
     def __init__(self):
@@ -586,11 +601,9 @@ class LizMain(pygame.sprite.Sprite):
         self.ammotype = 0
         self.ammoswitchpressed = False
 
-
     # dying animation controller
 
     def swansong(self):
-
         self.deathtimer += 1
         self.immune = False
         self.immunetimer = 0
@@ -665,7 +678,6 @@ class LizMain(pygame.sprite.Sprite):
             self.pos -= self.vel
 
         if ouch and not self.gothit and self.hittimer == 0 and not self.immune:
-
             self.health -= ouch[0].attack
             xcor = ((self.rect.centerx * 2) + ouch[0].rect.centerx) // 3
             ycor = ((self.rect.centery * 2) + ouch[0].rect.centery) // 3
@@ -692,7 +704,6 @@ class LizMain(pygame.sprite.Sprite):
             self.hittimer = 0
 
         elif yikes and not self.gothit and self.hittimer == 0 and not self.immune:
-
             self.health -= 20
 
             self.gothit = True
@@ -740,25 +751,28 @@ class LizMain(pygame.sprite.Sprite):
 
         elif self.dying:
             if self.reverse:
-                screen.blit(self.deathsurf, (self.rect.centerx, (self.rect.centery + self.yoffset)))
+                screen.blit(
+                    self.deathsurf,
+                    (self.rect.centerx, (self.rect.centery + self.yoffset)),
+                )
             if not self.reverse:
-                screen.blit(pygame.transform.flip(self.deathsurf, True, False),
-                            (self.rect.centerx, (self.rect.centery + self.yoffset)))
+                screen.blit(
+                    pygame.transform.flip(self.deathsurf, True, False),
+                    (self.rect.centerx, (self.rect.centery + self.yoffset)),
+                )
 
         elif self.melee:
-
             if not self.meleereverse:
-
                 blitplace = self.rect.center + vec(-140, -90)
                 blitplace += self.blitoffset
                 screen.blit(self.meleesurf, (blitplace))
 
             elif self.meleereverse:
-
                 blitplace = self.rect.center + vec(-140, -90)
                 blitplace += self.blitoffset
-                screen.blit(pygame.transform.flip(self.meleesurf, True, False), blitplace)
-
+                screen.blit(
+                    pygame.transform.flip(self.meleesurf, True, False), blitplace
+                )
 
         else:
             screen.blit(legs.surf, legs.rect)
@@ -771,7 +785,6 @@ class LizMain(pygame.sprite.Sprite):
     # melee strike function:
 
     def whack(self, direction):
-
         lizpos = vec(liz.rect.center)
         mousepos = vec(pygame.mouse.get_pos())
         if mousepos.x >= lizpos.x:
@@ -788,7 +801,6 @@ class LizMain(pygame.sprite.Sprite):
             self.meleestate = "down"
 
         if self.meleetimer < 3:
-
             if not self.grounded:
                 if direction == "up":
                     liz.vel.y -= 10
@@ -802,7 +814,6 @@ class LizMain(pygame.sprite.Sprite):
         if 8 > self.meleetimer < 12:
             if not self.grounded:
                 if direction == "down":
-
                     liz.vel.x = 0
                     liz.vel.y += 5
                     if liz.vel.y > 45:
@@ -821,16 +832,20 @@ class LizMain(pygame.sprite.Sprite):
                 self.meleesurf = Lizmelee[picindex]
             elif direction == "up":
                 increment = 90 / 7
-                self.meleesurf = pygame.transform.rotate(Lizmelee[picindex], (picindex * increment))
-                self.blitoffset.y = (picindex * -15)
+                self.meleesurf = pygame.transform.rotate(
+                    Lizmelee[picindex], (picindex * increment)
+                )
+                self.blitoffset.y = picindex * -15
                 if not self.meleereverse:
-                    self.blitoffset.x = (picindex * 10)
+                    self.blitoffset.x = picindex * 10
             elif direction == "down":
                 increment = (90 / 7) * -1
-                self.meleesurf = pygame.transform.rotate(Lizmelee[picindex], (picindex * increment))
-                self.blitoffset.y = (picindex * -15)
+                self.meleesurf = pygame.transform.rotate(
+                    Lizmelee[picindex], (picindex * increment)
+                )
+                self.blitoffset.y = picindex * -15
                 if self.meleereverse:
-                    self.blitoffset.x = (picindex * 10)
+                    self.blitoffset.x = picindex * 10
         else:
             if direction == "side":
                 self.meleesurf = Lizmelee[6]
@@ -868,7 +883,6 @@ class LizMain(pygame.sprite.Sprite):
             allsprites.add(hurtbox)
 
         if self.meleetimer > 16:
-
             if direction == "down" and not self.grounded:
                 self.meleetimer = 16
 
@@ -927,8 +941,7 @@ class LizMain(pygame.sprite.Sprite):
                 if not wheely:
                     self.ammoswitchpressed = False
 
-
-# firing the gatling:
+        # firing the gatling:
 
         if self.mousekey[0] and not self.gothit and not self.dying and not self.melee:
             if not gatling.spinning and not self.dying:
@@ -937,7 +950,12 @@ class LizMain(pygame.sprite.Sprite):
                 gatling.fire()
         if not self.mousekey[0] and gatling.spinning:
             gatling.winddown()
-        if self.dying or self.gothit or self.ammo[self.ammotype] == 0 and gatling.spinning:
+        if (
+            self.dying
+            or self.gothit
+            or self.ammo[self.ammotype] == 0
+            and gatling.spinning
+        ):
             gatling.winddown()
         # move left and right:
         if key[K_d] and not self.gothit and not self.dying:
@@ -945,8 +963,6 @@ class LizMain(pygame.sprite.Sprite):
 
         if key[K_a] and not self.gothit and not self.dying:
             self.vel.x -= self.acc.x
-
-
 
         # setting melee token if grounded and not pressing melee button:
 
@@ -966,7 +982,6 @@ class LizMain(pygame.sprite.Sprite):
             self.melee = True
 
         if self.melee and self.meleestate == "null":
-
             lizpos = vec(liz.rect.center)
             mousepos = vec(pygame.mouse.get_pos())
             ydif = lizpos.y - mousepos.y
@@ -996,7 +1011,6 @@ class LizMain(pygame.sprite.Sprite):
         if not key[K_a] and not key[K_d]:
             key = 0
         if self.grounded:
-
             legs.run(int(self.vel.x), key)
         else:
             legs.airborne(int(self.vel.x))

--- a/chaingirl.py
+++ b/chaingirl.py
@@ -6,7 +6,7 @@ import pygame
 from pygame import *
 import sys
 
-#setup stuff
+# setup stuff
 
 from initialising import *
 
@@ -33,32 +33,35 @@ from enemies import *
 # main game loop
 
 while running:
-
     screen.blit(background, (0, 0))
     depth.update()
     ref.update()
     for entity in allsprites:
         entity.update()
     liz.update()
-#    cursor.update()
+    #    cursor.update()
 
-# this is for rendering some data on the screen for testing and debugging ets.
+    # this is for rendering some data on the screen for testing and debugging ets.
 
     terminal = font.render("angle: " + str(ref.angle), True, ("black"))
     frame = font.render("frame number: " + str(torso.frame), True, ("black"))
     rotangle = font.render("rotation angle: " + str(torso.anglecheck), True, ("black"))
     lizvelocity = font.render("Lizzy velocity: " + str(liz.vel), True, ("black"))
     lizposition = font.render("Lizzy position: " + str(liz.pos), True, ("black"))
-    virtualcoords = font.render("level virtual position: " + str(ref.virtualposition), True, ("black"))
-    spritenumber = font.render("number of sprites: " + str(len(allsprites)), True, ("black"))
+    virtualcoords = font.render(
+        "level virtual position: " + str(ref.virtualposition), True, ("black")
+    )
+    spritenumber = font.render(
+        "number of sprites: " + str(len(allsprites)), True, ("black")
+    )
     screen.blit(virtualcoords, (20, 20))
-    screen.blit(terminal, (20,40))
+    screen.blit(terminal, (20, 40))
     screen.blit(lizvelocity, (20, 60))
-    screen.blit(spritenumber, (20,80))
+    screen.blit(spritenumber, (20, 80))
 
     pygame.display.update()
 
-# quit conditions
+    # quit conditions
 
     for event in pygame.event.get():
         if event.type == QUIT:
@@ -68,16 +71,11 @@ while running:
     if key[K_ESCAPE]:
         running = False
 
-
-#    if ref.death == True:
-#        running = False
+    #    if ref.death == True:
+    #        running = False
 
     pygame.time.Clock().tick(30)
 
 
 pygame.quit()
 sys.exit()
-
-
-
-

--- a/enemies.py
+++ b/enemies.py
@@ -12,11 +12,11 @@ from FX import *
 class kamaker(pygame.sprite.Sprite):
     def __init__(self, coords):
         super().__init__()
-        self.surf = pygame.Surface((200,100))
+        self.surf = pygame.Surface((200, 100))
         self.killed = False
-        self.surf.fill((0,0,0))
+        self.surf.fill((0, 0, 0))
         self.surf.set_alpha(255)
-        self.surf.set_colorkey((0,0,0))
+        self.surf.set_colorkey((0, 0, 0))
         self.rect = self.surf.get_rect()
         self.hardblocked = False
         self.gothit = False
@@ -44,7 +44,6 @@ class kamaker(pygame.sprite.Sprite):
         self.attack = 20
 
     def gethit(self, hitcoords, damage, type):
-
         self.gothit = True
         self.health -= damage
         chance = random.randint(0, 2)
@@ -74,7 +73,6 @@ class kamaker(pygame.sprite.Sprite):
             self.killed = True
 
     def move(self):
-
         self.oldpos = self.pos
         self.pos = vec(self.rect.midbottom)
         if not self.grounded:
@@ -89,11 +87,8 @@ class kamaker(pygame.sprite.Sprite):
             self.pos.x -= self.speed
         self.rect.midbottom = self.pos
 
-
     def edgedetect(self):
-
         if self.grounded:
-
             if not self.reversed:
                 self.rect.centerx -= 150
             elif self.reversed:
@@ -114,7 +109,6 @@ class kamaker(pygame.sprite.Sprite):
             # self.rect.midbottom = self.pos
 
     def platformcheck(self):
-
         hits = pygame.sprite.spritecollide(self, platforms, False)
         if hits:
             for i in hits:
@@ -140,7 +134,6 @@ class kamaker(pygame.sprite.Sprite):
             self.hardblocked = False
 
     def render(self):
-
         if not self.reversed:
             screen.blit(self.surf, self.rect)
             if self.gothit:
@@ -152,7 +145,9 @@ class kamaker(pygame.sprite.Sprite):
                 screen.blit(flipped, self.rect, special_flags=BLEND_RGB_ADD)
 
         if self.health < 25:
-            healthrect = pygame.Rect(self.rect.left, self.rect.bottom, self.health * 5, 5)
+            healthrect = pygame.Rect(
+                self.rect.left, self.rect.bottom, self.health * 5, 5
+            )
             pygame.draw.rect(screen, ("red"), healthrect)
         self.surf.fill((0, 0, 0))
 
@@ -165,7 +160,6 @@ class kamaker(pygame.sprite.Sprite):
         self.platformcheck()
         self.hardblockscheck()
 
-
         if self.deathtimer < 5:
             self.animate()
             self.render()
@@ -177,13 +171,14 @@ class kamaker(pygame.sprite.Sprite):
     def deathani(self):
         if self.deathtimer == 0:
             for i in range(30):
-                x = self.rect.centerx + (random.randint( -30, 30))
+                x = self.rect.centerx + (random.randint(-30, 30))
                 y = self.rect.centery + (random.randint(-10, 10))
-                randomcol = random.randint( 170, 230)
-                part1 = particle(x, y, 0, 0, 0, 0, 1, 4, (50, randomcol, 20), screen, (0 ,0 ,0))
+                randomcol = random.randint(170, 230)
+                part1 = particle(
+                    x, y, 0, 0, 0, 0, 1, 4, (50, randomcol, 20), screen, (0, 0, 0)
+                )
                 self.partlist1.append(part1)
         if self.deathtimer < 8:
-
             for i in self.partlist1:
                 i.draw()
 
@@ -191,8 +186,20 @@ class kamaker(pygame.sprite.Sprite):
             for i in range(50):
                 x = self.rect.centerx + (random.randint(-40, 40))
                 y = self.rect.centery + (random.randint(-20, 20))
-                randomcol2 = random.randint( 170, 230)
-                part2 = particle(x, y, random.randint(-15, 15), random.randint(-30, 0), 0, 1, 8, -0.4, (50, randomcol2, 20), screen, (0 ,0 ,0))
+                randomcol2 = random.randint(170, 230)
+                part2 = particle(
+                    x,
+                    y,
+                    random.randint(-15, 15),
+                    random.randint(-30, 0),
+                    0,
+                    1,
+                    8,
+                    -0.4,
+                    (50, randomcol2, 20),
+                    screen,
+                    (0, 0, 0),
+                )
                 self.partlist2.append(part2)
         if self.deathtimer > 6 and self.deathtimer < 20:
             for i in self.partlist2:
@@ -202,7 +209,6 @@ class kamaker(pygame.sprite.Sprite):
             self.kill()
         self.deathtimer += 1
 
-
     def animate(self):
         self.frontpawfront()
         self.frontpawback()
@@ -210,11 +216,11 @@ class kamaker(pygame.sprite.Sprite):
         self.backpawback()
         self.surf.blit(kamakerpaw, (self.xpos1, self.ypos1))
         self.surf.blit(kamakerpaw, (self.xpos3, self.ypos3))
-        self.surf.blit(kamakerbody, (50,15))
-        self.surf.blit(kamakertail, (160,50))
+        self.surf.blit(kamakerbody, (50, 15))
+        self.surf.blit(kamakertail, (160, 50))
         self.surf.blit(kamakerpaw, (self.xpos2, self.ypos2))
         self.surf.blit(kamakerpaw, (self.xpos4, self.ypos4))
-        self.surf.blit(kamakerhead, (0,0))
+        self.surf.blit(kamakerhead, (0, 0))
 
     def frontpawfront(self):
         if self.timer < 10:
@@ -229,7 +235,7 @@ class kamaker(pygame.sprite.Sprite):
     def frontpawback(self):
         if self.timer < 5:
             self.xpos2 -= 5
-            self.ypos2 -=5
+            self.ypos2 -= 5
         elif self.timer >= 5 and self.timer < 10:
             self.xpos2 -= 5
             self.ypos2 += 5
@@ -249,12 +255,9 @@ class kamaker(pygame.sprite.Sprite):
     def backpawback(self):
         if self.timer < 5:
             self.xpos4 -= 5
-            self.ypos4 -=5
+            self.ypos4 -= 5
         elif self.timer >= 5 and self.timer < 10:
             self.xpos4 -= 5
             self.ypos4 += 5
         elif self.timer >= 10:
             self.xpos4 += 5
-
-
-

--- a/images.py
+++ b/images.py
@@ -1,132 +1,180 @@
 import pygame
 import os
 
-Lizhit = pygame.image.load(os.path.join('images', 'lizhit.png')).convert_alpha()
+Lizhit = pygame.image.load(os.path.join("images", "lizhit.png")).convert_alpha()
 
 groundblocks = [
-    pygame.image.load(os.path.join('images', 'groundboxstraight.png')).convert(),
-    pygame.image.load(os.path.join('images', 'groundboxstraightmid.png')).convert(),
-    pygame.image.load(os.path.join('images', 'groundboxupramp.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'groundboxstraightramp.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'groundboxdownramp.png')).convert_alpha(),
-    pygame.transform.flip((pygame.image.load(os.path.join('images', 'groundboxupramp.png')).convert_alpha()), True, False),
-    pygame.transform.flip((pygame.image.load(os.path.join('images', 'groundboxstraightramp.png')).convert_alpha()), True,
-                          False),
-    pygame.transform.flip((pygame.image.load(os.path.join('images', 'groundboxdownramp.png')).convert_alpha()), True,
-                          False),
-
+    pygame.image.load(os.path.join("images", "groundboxstraight.png")).convert(),
+    pygame.image.load(os.path.join("images", "groundboxstraightmid.png")).convert(),
+    pygame.image.load(os.path.join("images", "groundboxupramp.png")).convert_alpha(),
+    pygame.image.load(
+        os.path.join("images", "groundboxstraightramp.png")
+    ).convert_alpha(),
+    pygame.image.load(os.path.join("images", "groundboxdownramp.png")).convert_alpha(),
+    pygame.transform.flip(
+        (
+            pygame.image.load(
+                os.path.join("images", "groundboxupramp.png")
+            ).convert_alpha()
+        ),
+        True,
+        False,
+    ),
+    pygame.transform.flip(
+        (
+            pygame.image.load(
+                os.path.join("images", "groundboxstraightramp.png")
+            ).convert_alpha()
+        ),
+        True,
+        False,
+    ),
+    pygame.transform.flip(
+        (
+            pygame.image.load(
+                os.path.join("images", "groundboxdownramp.png")
+            ).convert_alpha()
+        ),
+        True,
+        False,
+    ),
 ]
 
 Lizmelee = [
-    pygame.image.load(os.path.join('images', 'melee01.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'melee02.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'melee03.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'melee04.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'melee05.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'melee06.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'melee07.png')).convert_alpha(),
+    pygame.image.load(os.path.join("images", "melee01.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "melee02.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "melee03.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "melee04.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "melee05.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "melee06.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "melee07.png")).convert_alpha(),
 ]
 
 
 Lizdeath = [
-    pygame.image.load(os.path.join('images', 'lizdeath01.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'lizdeath02.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'lizdeath03.png')).convert_alpha(),
+    pygame.image.load(os.path.join("images", "lizdeath01.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "lizdeath02.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "lizdeath03.png")).convert_alpha(),
 ]
 
-kamakerbody = pygame.image.load(os.path.join('images', 'kamakerbody2.png')).convert_alpha()
-kamakerhead = pygame.image.load(os.path.join('images', 'kamakerhead.png')).convert_alpha()
-kamakerpaw = pygame.image.load(os.path.join('images', 'kamakerpaw.png')).convert_alpha()
-kamakertail = pygame.image.load(os.path.join('images', 'kamakertail.png')).convert_alpha()
+kamakerbody = pygame.image.load(
+    os.path.join("images", "kamakerbody2.png")
+).convert_alpha()
+kamakerhead = pygame.image.load(
+    os.path.join("images", "kamakerhead.png")
+).convert_alpha()
+kamakerpaw = pygame.image.load(os.path.join("images", "kamakerpaw.png")).convert_alpha()
+kamakertail = pygame.image.load(
+    os.path.join("images", "kamakertail.png")
+).convert_alpha()
 
-rocktile = pygame.image.load(os.path.join('images', 'rockblock.png')).convert_alpha()
+rocktile = pygame.image.load(os.path.join("images", "rockblock.png")).convert_alpha()
 
 tracer = [
-    pygame.image.load(os.path.join('images', 'tracer.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'tracerblue.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'tracerred.png')).convert_alpha(),
+    pygame.image.load(os.path.join("images", "tracer.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "tracerblue.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "tracerred.png")).convert_alpha(),
 ]
 
 ammoboxes = [
-    pygame.image.load(os.path.join('images', 'ammoyellow.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'ammoblue.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'ammored.png')).convert_alpha(),
+    pygame.image.load(os.path.join("images", "ammoyellow.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "ammoblue.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "ammored.png")).convert_alpha(),
 ]
 
 hitpix = [
-    pygame.image.load(os.path.join('images', 'hit1.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'hit2.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'hit3.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'hit4.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'hit5.png')).convert_alpha(),
-
+    pygame.image.load(os.path.join("images", "hit1.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "hit2.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "hit3.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "hit4.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "hit5.png")).convert_alpha(),
 ]
 
 barrelpix = [
-    pygame.image.load(os.path.join('images', 'barrels01.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'barrels02.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'barrels03.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'barrels04.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'barrels05.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'barrels06.png')).convert_alpha(),
-
+    pygame.image.load(os.path.join("images", "barrels01.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "barrels02.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "barrels03.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "barrels04.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "barrels05.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "barrels06.png")).convert_alpha(),
 ]
 
 groundtiles = [
-    pygame.image.load(os.path.join('images', 'groundlefttop.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'groundmidtop.png')).convert(),
-    pygame.image.load(os.path.join('images', 'groundbotleft.png')).convert(),
-    pygame.image.load(os.path.join('images', 'groundbotmid.png')).convert(),
-
-    pygame.transform.flip((pygame.image.load(os.path.join('images', 'groundlefttop.png')).convert_alpha()), True, False),
-    pygame.transform.flip((pygame.image.load(os.path.join('images', 'groundbotleft.png')).convert()), True, False)
+    pygame.image.load(os.path.join("images", "groundlefttop.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "groundmidtop.png")).convert(),
+    pygame.image.load(os.path.join("images", "groundbotleft.png")).convert(),
+    pygame.image.load(os.path.join("images", "groundbotmid.png")).convert(),
+    pygame.transform.flip(
+        (
+            pygame.image.load(
+                os.path.join("images", "groundlefttop.png")
+            ).convert_alpha()
+        ),
+        True,
+        False,
+    ),
+    pygame.transform.flip(
+        (pygame.image.load(os.path.join("images", "groundbotleft.png")).convert()),
+        True,
+        False,
+    ),
 ]
 
-Lizlegstill = pygame.image.load(os.path.join('images', 'walkstilla.png')).convert_alpha()
-Liztorsostill = pygame.image.load(os.path.join('images', 'torso01a.png')).convert_alpha()
+Lizlegstill = pygame.image.load(
+    os.path.join("images", "walkstilla.png")
+).convert_alpha()
+Liztorsostill = pygame.image.load(
+    os.path.join("images", "torso01a.png")
+).convert_alpha()
 Lizlegsair = [
-    pygame.image.load(os.path.join('images', 'jump1.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'jump2.png')).convert_alpha(),
+    pygame.image.load(os.path.join("images", "jump1.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "jump2.png")).convert_alpha(),
 ]
 Lizlegsaireverse = [
-    pygame.transform.flip((pygame.image.load(os.path.join('images', 'jump1.png')).convert_alpha()), True, False),
-    pygame.transform.flip((pygame.image.load(os.path.join('images', 'jump2.png')).convert_alpha()), True, False)
+    pygame.transform.flip(
+        (pygame.image.load(os.path.join("images", "jump1.png")).convert_alpha()),
+        True,
+        False,
+    ),
+    pygame.transform.flip(
+        (pygame.image.load(os.path.join("images", "jump2.png")).convert_alpha()),
+        True,
+        False,
+    ),
 ]
 Lizlegsrun = [
-    pygame.image.load(os.path.join('images', 'walk01a.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'walk02a.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'walk03a.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'walk04a.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'walk05a.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'walk06a.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'walk07a.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'walk08a.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'walk09a.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'walk10a.png')).convert_alpha(),
-
+    pygame.image.load(os.path.join("images", "walk01a.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "walk02a.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "walk03a.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "walk04a.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "walk05a.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "walk06a.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "walk07a.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "walk08a.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "walk09a.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "walk10a.png")).convert_alpha(),
 ]
 Lizlegsreverse = []
 for i in range(len(Lizlegsrun)):
     Lizlegsreverse.append(pygame.transform.flip((Lizlegsrun[i]), True, False))
 
 Liztorsopix = [
-    pygame.image.load(os.path.join('images', 'torsosmall00.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'torsosmall01.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'torsosmall02.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'torsosmall03.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'torsosmall04.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'torsosmall05.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'torsosmall06.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'torsosmall07.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'torsosmall08.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'torsosmall09.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'torsosmall10.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'torsosmall11.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'torsosmall12.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'torsosmall13.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'torsosmall14.png')).convert_alpha(),
-    pygame.image.load(os.path.join('images', 'torsosmall15.png')).convert_alpha(),
-
+    pygame.image.load(os.path.join("images", "torsosmall00.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "torsosmall01.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "torsosmall02.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "torsosmall03.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "torsosmall04.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "torsosmall05.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "torsosmall06.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "torsosmall07.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "torsosmall08.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "torsosmall09.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "torsosmall10.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "torsosmall11.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "torsosmall12.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "torsosmall13.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "torsosmall14.png")).convert_alpha(),
+    pygame.image.load(os.path.join("images", "torsosmall15.png")).convert_alpha(),
 ]
 Liztorsoreverse = []
 for i in range(len(Liztorsopix)):

--- a/initialising.py
+++ b/initialising.py
@@ -7,14 +7,14 @@ pygame.init()
 flags = FULLSCREEN | DOUBLEBUF
 screen = pygame.display.set_mode((0, 0), flags, 16)
 # screen = pygame.display.set_mode((600, 600))
-backgroundimage = pygame.image.load(os.path.join('images', 'bg01.jpg')).convert()
+backgroundimage = pygame.image.load(os.path.join("images", "bg01.jpg")).convert()
 screensize = screen.get_size()
 background = pygame.transform.scale(backgroundimage, screensize)
 running = True
 vec = pygame.math.Vector2
 # pygame.mouse.set_visible(False)
-mousesurf = pygame.image.load(os.path.join('images', 'reticle.png'))
-reticursor = pygame.cursors.Cursor((15,15), mousesurf)
+mousesurf = pygame.image.load(os.path.join("images", "reticle.png"))
+reticursor = pygame.cursors.Cursor((15, 15), mousesurf)
 pygame.mouse.set_cursor(reticursor)
 font = pygame.font.SysFont("comicsansms", 20)
 pygame.event.set_allowed([QUIT, KEYDOWN, KEYUP])
@@ -30,7 +30,8 @@ hardblocks = pygame.sprite.Group()
 enemies = pygame.sprite.Group()
 hazards = pygame.sprite.Group()
 
-depthlayer = pygame.image.load(os.path.join('images', 'depthlayer.png')).convert_alpha()
+depthlayer = pygame.image.load(os.path.join("images", "depthlayer.png")).convert_alpha()
+
 
 class depthbg(pygame.sprite.Sprite):
     def __init__(self, coords):
@@ -39,6 +40,7 @@ class depthbg(pygame.sprite.Sprite):
         self.image = depthlayer
         self.rect = self.image.get_rect()
         self.rect.center = self.pos
+
     def update(self):
         self.rect.center = self.pos
         screen.blit(self.image, self.rect)

--- a/levelgen.py
+++ b/levelgen.py
@@ -20,17 +20,17 @@ def basicplatformconstructor(position, size):
 
     for i in range(size):
         blockpos.x += 100
-        midblock = basicplatformblock(groundtiles, 1, blockpos , True)
+        midblock = basicplatformblock(groundtiles, 1, blockpos, True)
         allsprites.add(midblock)
         platforms.add(midblock)
 
     blockpos.x += 100
-    rightcorner = basicplatformblock(groundtiles, 4, blockpos , True)
+    rightcorner = basicplatformblock(groundtiles, 4, blockpos, True)
     allsprites.add(rightcorner)
     platforms.add(rightcorner)
 
     while blockpos.y < 1024:
-        blockpos.x -= ((size + 1) * 100)
+        blockpos.x -= (size + 1) * 100
         blockpos.y += 100
 
         leftwall = basicplatformblock(groundtiles, 2, blockpos, False)
@@ -45,35 +45,37 @@ def basicplatformconstructor(position, size):
         rightwall = basicplatformblock(groundtiles, 5, blockpos, False)
         allsprites.add(rightwall)
 
+
 # a constructor for sprite level building blocks used in the above constructor
+
 
 class basicplatformblock(pygame.sprite.Sprite):
     def __init__(self, imageset, index, position, hardtop):
         super().__init__()
-        self.image = (imageset[index])
-        self.surf = pygame.surface.Surface ((100,100), pygame.SRCALPHA)
-        
+        self.image = imageset[index]
+        self.surf = pygame.surface.Surface((100, 100), pygame.SRCALPHA)
+
         self.rect = self.surf.get_rect()
         self.rect.topleft = position
         self.hardtop = hardtop
-        self.hole = pygame.surface.Surface ((20,20))
+        self.hole = pygame.surface.Surface((20, 20))
         self.hole.fill(("black"))
         self.hole.set_alpha(0)
         self.surf.blit(self.image, (0, 0))
+
     def update(self):
         if self.hardtop:
             self.playercheck()
-        self.surf.blit(self.hole, (20,20))
+        self.surf.blit(self.hole, (20, 20))
         screen.blit(self.surf, self.rect)
 
     # check if player is standing on block
     def playercheck(self):
-
         hits = pygame.sprite.collide_rect(self, liz)
 
         if hits:
             if liz.pos.y <= (self.rect.top + 50):
-                liz.pos.y = (self.rect.top + 1)
+                liz.pos.y = self.rect.top + 1
                 liz.vel.y = 0
                 liz.grounded = True
             else:
@@ -82,40 +84,48 @@ class basicplatformblock(pygame.sprite.Sprite):
 
 # hard block class (blocks player movement and normal attacks, also is a platform)
 
+
 class hardblock(pygame.sprite.Sprite):
     def __init__(self, image, position):
         super().__init__()
         self.surf = image
         self.rect = self.surf.get_rect()
         self.rect.topleft = position
+
     def update(self):
         self.playercheck()
         screen.blit(self.surf, self.rect)
 
     # check if player is standing on block
     def playercheck(self):
-
         hits = pygame.sprite.collide_rect(self, liz)
 
         if hits:
             revert = liz.pos.x - liz.vel.x
             reverty = liz.pos.y - liz.vel.y
 
-            if self.rect.center[1] < liz.rect.bottom + 10 and self.rect.center[1] > liz.rect.top - 10:
+            if (
+                self.rect.center[1] < liz.rect.bottom + 10
+                and self.rect.center[1] > liz.rect.top - 10
+            ):
                 liz.pos.x = revert
                 liz.rect.midbottom = liz.pos
             elif (liz.pos.y <= (self.rect.top + 50)) and (
-                    (liz.vel.x <= 0 and liz.rect.center[0] - self.rect.center[0] < 50) or (
-                    liz.vel.x >= 0 and liz.rect.center[0] - self.rect.center[0] > -50)):
-                liz.pos.y = (self.rect.top + 1)
+                (liz.vel.x <= 0 and liz.rect.center[0] - self.rect.center[0] < 50)
+                or (liz.vel.x >= 0 and liz.rect.center[0] - self.rect.center[0] > -50)
+            ):
+                liz.pos.y = self.rect.top + 1
                 liz.vel.y = 0
                 liz.grounded = True
             else:
                 liz.grounded = False
 
             if liz.vel.y < 0:
-                if (liz.vel.x <= 0 and liz.rect.center[0] - self.rect.center[0] < 45) or (
-                        liz.vel.x >= 0 and liz.rect.center[0] - self.rect.center[0] > -45):
+                if (
+                    liz.vel.x <= 0 and liz.rect.center[0] - self.rect.center[0] < 45
+                ) or (
+                    liz.vel.x >= 0 and liz.rect.center[0] - self.rect.center[0] > -45
+                ):
                     liz.vel.y = 0
                     liz.pos.y = reverty
 
@@ -133,6 +143,7 @@ class hardblock(pygame.sprite.Sprite):
             elif liz.ammotype == 2:
                 poef = explosive(impactsite)
                 allsprites.add(poef)
+
 
 class groundblock(pygame.sprite.Sprite):
     def __init__(self, orient, pos):
@@ -182,7 +193,6 @@ class groundblock(pygame.sprite.Sprite):
         if type == "flattop":
             threshold = self.rect.top
         elif type == "startramp":
-
             threshold = self.rect.bottom - (cos(degreecor) + 1) * 100
 
         elif type == "slant":
@@ -194,9 +204,10 @@ class groundblock(pygame.sprite.Sprite):
         tik = pygame.sprite.collide_rect(self, liz)
         if tik:
             origin = vec(liz.rect.center - liz.vel)
-            if liz.rect.bottom > threshold and \
-                    (abs(origin.y - self.rect.centery) > abs(origin.x - self.rect.centerx) or self.treaded):
-
+            if liz.rect.bottom > threshold and (
+                abs(origin.y - self.rect.centery) > abs(origin.x - self.rect.centerx)
+                or self.treaded
+            ):
                 liz.rect.bottom = threshold + 1
                 liz.pos.y = liz.rect.bottom
                 if not gatling.firing:
@@ -205,24 +216,28 @@ class groundblock(pygame.sprite.Sprite):
                 self.treaded = True
 
     def leftcheck(self):
-
         tik = pygame.sprite.collide_rect(self, liz)
         if tik and not self.treaded:
             origin = vec(liz.rect.center - liz.vel)
-            if liz.rect.right < self.rect.centerx and \
-                    abs(origin.y - self.rect.centery) < abs(origin.x - self.rect.centerx) and \
-                    liz.rect.bottom > self.rect.top:
+            if (
+                liz.rect.right < self.rect.centerx
+                and abs(origin.y - self.rect.centery)
+                < abs(origin.x - self.rect.centerx)
+                and liz.rect.bottom > self.rect.top
+            ):
                 liz.pos -= liz.vel
                 liz.vel.x = 0
-
 
     def rightcheck(self):
         tik = pygame.sprite.collide_rect(self, liz)
         if tik and not self.treaded:
             origin = vec(liz.rect.center - liz.vel)
-            if liz.rect.right < self.rect.centerx and \
-                    abs(origin.y - self.rect.centery) < abs(origin.x - self.rect.centerx) and \
-                    liz.rect.bottom > self.rect.top:
+            if (
+                liz.rect.right < self.rect.centerx
+                and abs(origin.y - self.rect.centery)
+                < abs(origin.x - self.rect.centerx)
+                and liz.rect.bottom > self.rect.top
+            ):
                 liz.pos -= liz.vel
                 liz.vel.x = 0
 
@@ -246,6 +261,7 @@ class groundblock(pygame.sprite.Sprite):
 
             # self.rightcheck()
 
+
 def hardblockplacement(hbcoords, image):
     for i in range(len(hbcoords)):
         hblock = hardblock(image, hbcoords[i])
@@ -253,28 +269,29 @@ def hardblockplacement(hbcoords, image):
         hardblocks.add(hblock)
         allsprites.add(hblock)
 
+
 # generating a level
 
 hardblocklist = [
-    (200,600),
-    (300,600),
-    (0,900),
-    (0,800),
-    (0,700),
-    (0,600),
-    (100,600),
-    (600,700)
+    (200, 600),
+    (300, 600),
+    (0, 900),
+    (0, 800),
+    (0, 700),
+    (0, 600),
+    (100, 600),
+    (600, 700),
 ]
 
-basicplatformconstructor((400,800), 5)
-basicplatformconstructor((1000,900), 2)
-basicplatformconstructor((1700,900), 2)
-basicplatformconstructor((2600,200), 2)
-basicplatformconstructor((2300,400), 2)
-basicplatformconstructor((2400,600), 3)
-basicplatformconstructor((2200,800), 5)
-basicplatformconstructor((0,1000), 15)
-basicplatformconstructor((2000,1000), 10)
+basicplatformconstructor((400, 800), 5)
+basicplatformconstructor((1000, 900), 2)
+basicplatformconstructor((1700, 900), 2)
+basicplatformconstructor((2600, 200), 2)
+basicplatformconstructor((2300, 400), 2)
+basicplatformconstructor((2400, 600), 3)
+basicplatformconstructor((2200, 800), 5)
+basicplatformconstructor((0, 1000), 15)
+basicplatformconstructor((2000, 1000), 10)
 
 ground = groundblock("top", (3300, 1100))
 allsprites.add(ground)

--- a/makefile
+++ b/makefile
@@ -1,0 +1,7 @@
+all: black
+
+black:
+	black .
+
+requirements:
+	pip install -r requirements-dev.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+black


### PR DESCRIPTION
### `black`

`black` is the industry-standard tool to automatically format Python code. No more doubts like: "Should this be one line or split over multiple lines?" or "Do I have spaces between the variables and the equals sign?" `black` will take care of it all.

This saves you some brain space, but the real benefit is when comparing code and looking for changes. This is, of course, particularly relevant when working with multiple contributors. If all of them use `black` then you know for certain that all the changes in a pull request or other "diff" are meaningful and you don't need sift through formatting changes to find the "real" changes. The formatting will all be standardized.

In this PR I've applied `black` to all code. This means the changes in the `.py` files are only formatting-related. No code has really been changed.

### `requirements-dev.txt`

This file is similar to `requirements.txt` and lists the libraries required for developing on the Lizzy game. Libraries in this file are required for developing, but for running the game. That's what `requirements.txt` is for.

### `makefile`

A `makefile` is a standard file automating standard steps taking during development using the `make` tool. This is available by default on Linux and Mac. I'm not sure about Windows. You might have to install it. I see [here](https://stackoverflow.com/a/54133058) that these days it's also present on Windows.

You can type `make` to apply `black` automatically to all your code. We can add other commands to it later.
